### PR TITLE
mixin:transition implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "hirola",
  "hirola-macros",
  "html-escape",
+ "js-sys",
  "matchit",
  "ref-cast",
  "regex",
@@ -439,9 +440,9 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1019,9 +1020,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1031,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -1058,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1068,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1081,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-bindgen-test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ docsrs = ["document-features"]
 ## Enables form mixins and utilities
 form = ["hirola-form"]
 
-
+## Enables transition mixin
+transition = ["hirola-core/transition"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/crates/hirola-core/Cargo.toml
+++ b/crates/hirola-core/Cargo.toml
@@ -64,8 +64,8 @@ dom = []
 ssr = ["html-escape", "web-sys/Event"]
 router = ["matchit", "web-sys/History", "web-sys/Location", "web-sys/HtmlLinkElement"]
 global-state = ["anymap"]
-async = ["wasm-bindgen-futures", "js-sys"]
-transition = ["async"]
+async = ["wasm-bindgen-futures"]
+transition = ["async", "js-sys"]
 
 [[bench]]
 harness = false

--- a/crates/hirola-core/Cargo.toml
+++ b/crates/hirola-core/Cargo.toml
@@ -26,6 +26,7 @@ regex = "1"
 matchit = { version = "0.6", optional = true }
 anymap = { version = "1.0.0-beta.2", optional = true }
 wasm-bindgen-futures = { version = "0.4.29", optional = true  }
+js-sys = { version = "0.3.60", optional = true }
 
 
 
@@ -63,7 +64,7 @@ dom = []
 ssr = ["html-escape", "web-sys/Event"]
 router = ["matchit", "web-sys/History", "web-sys/Location", "web-sys/HtmlLinkElement"]
 global-state = ["anymap"]
-async = ["wasm-bindgen-futures"]
+async = ["wasm-bindgen-futures", "js-sys"]
 
 [[bench]]
 harness = false

--- a/crates/hirola-core/Cargo.toml
+++ b/crates/hirola-core/Cargo.toml
@@ -65,6 +65,7 @@ ssr = ["html-escape", "web-sys/Event"]
 router = ["matchit", "web-sys/History", "web-sys/Location", "web-sys/HtmlLinkElement"]
 global-state = ["anymap"]
 async = ["wasm-bindgen-futures", "js-sys"]
+transition = ["async"]
 
 [[bench]]
 harness = false

--- a/crates/hirola-core/src/generic_node/dom_node.rs
+++ b/crates/hirola-core/src/generic_node/dom_node.rs
@@ -91,6 +91,25 @@ impl GenericNode for DomNode {
             .unwrap();
     }
 
+    /* 
+    #[cfg(feature = "async")]
+    fn append_child(&self, child: &Self) {
+        use wasm_bindgen_futures::spawn_local;
+        self.node.append_child(&child.node).unwrap();
+        let node = self.clone();
+        let child = child.clone();
+        node.node.append_child(&child.node).unwrap();
+        let task = async move {
+            
+            let el = child.node.unchecked_ref::<Element>();
+            crate::mixins::enter(el.clone()).await;
+            
+        };
+        let _fut = spawn_local(task);
+    }
+    */
+
+    
     fn append_child(&self, child: &Self) {
         self.node.append_child(&child.node).unwrap();
     }
@@ -105,6 +124,24 @@ impl GenericNode for DomNode {
         self.node.remove_child(&child.node).unwrap();
     }
 
+    #[cfg(feature = "async")]
+    fn replace_child(&self, old: &Self, new: &Self) {
+        let old = old.clone();
+        let new = new.clone();
+        let node = self.clone();
+        let task = async move {
+            let old_el = new.node.unchecked_ref::<Element>();
+            let new_el = old.node.unchecked_ref::<Element>();
+            crate::mixins::leave_transition(old_el.clone()).await;
+            node.node.replace_child(&old.node, &new.node).unwrap();
+            crate::mixins::enter_transition(new_el.clone()).await;
+        };
+        let _fut = wasm_bindgen_futures::spawn_local(task);
+
+    }
+
+    //fixme: seems like `old` and `new` is backwards?
+    #[cfg(not(feature = "async"))]
     fn replace_child(&self, old: &Self, new: &Self) {
         self.node.replace_child(&old.node, &new.node).unwrap();
     }

--- a/crates/hirola-core/src/generic_node/dom_node.rs
+++ b/crates/hirola-core/src/generic_node/dom_node.rs
@@ -90,25 +90,6 @@ impl GenericNode for DomNode {
             .set_attribute(name, value)
             .unwrap();
     }
-
-    /* 
-    #[cfg(feature = "async")]
-    fn append_child(&self, child: &Self) {
-        use wasm_bindgen_futures::spawn_local;
-        self.node.append_child(&child.node).unwrap();
-        let node = self.clone();
-        let child = child.clone();
-        node.node.append_child(&child.node).unwrap();
-        let task = async move {
-            
-            let el = child.node.unchecked_ref::<Element>();
-            crate::mixins::enter(el.clone()).await;
-            
-        };
-        let _fut = spawn_local(task);
-    }
-    */
-
     
     fn append_child(&self, child: &Self) {
         self.node.append_child(&child.node).unwrap();
@@ -173,7 +154,7 @@ impl GenericNode for DomNode {
     }
 
     
-    #[cfg(feature = "async")]
+    #[cfg(feature = "transition")]
     fn append_render(&self, child: Box<dyn Fn() -> Box<dyn crate::render::Render<Self>>>) {
 
         let parent = self.clone();
@@ -217,7 +198,7 @@ impl GenericNode for DomNode {
     }
     
 
-    #[cfg(not(feature = "async"))]
+    #[cfg(not(feature = "transition"))]
     fn append_render(&self, child: Box<dyn Fn() -> Box<dyn crate::render::Render<Self>>>) {
         let parent = self.clone();
         

--- a/crates/hirola-core/src/mixins.rs
+++ b/crates/hirola-core/src/mixins.rs
@@ -96,7 +96,7 @@ pub fn text<T: Display>(text: &Signal<T>) -> Box<dyn Fn(DomNode)> {
 }
 
 //show function for using mixin:transition feature
-#[cfg(feature = "async")]
+#[cfg(feature = "transition")]
 pub fn show(shown: &Signal<bool>) -> Box<dyn Fn(DomNode)> {
     let signal = shown.clone();
     let cb = move |node: DomNode| {
@@ -133,7 +133,7 @@ pub fn show(shown: &Signal<bool>) -> Box<dyn Fn(DomNode)> {
 }
 
 /// Mixin that adds text to a dom node
-#[cfg(not(feature = "async"))]
+#[cfg(not(feature = "transition"))]
 pub fn show(shown: &Signal<bool>) -> Box<dyn Fn(DomNode)> {
     let signal = shown.clone();
     let cb = move |node: DomNode| {
@@ -205,7 +205,7 @@ pub mod model {
 
 /// Mixin for playing with `transition`
 /// 
-/// _This mixin requires the following crate features to be activated: `async`_
+/// _This mixin requires the following crate features to be activated: `transition`_
 /// 
 /// The implementation is very similar to that in `VueJS` and `Alpine`. 
 /// 
@@ -254,8 +254,8 @@ pub mod model {
 ///     }
 /// } 
 /// ```
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+#[cfg(feature = "transition")]
+#[cfg_attr(docsrs, doc(cfg(feature = "transition")))]
 pub fn transition<'a>(signal: &'a Signal<String>, onenter: bool) -> Box<dyn Fn(DomNode) -> () + 'a> {
     let cb = move |node: DomNode| {
         let signal = signal.clone();
@@ -283,9 +283,11 @@ pub fn transition<'a>(signal: &'a Signal<String>, onenter: bool) -> Box<dyn Fn(D
 }
 
 
-//transition when element is entering
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+/// Transition function  when element is entering
+/// 
+/// For most case, you wont be needing this function as it is already implemented under the hood.
+#[cfg(feature = "transition")]
+#[cfg_attr(docsrs, doc(cfg(feature = "transition")))]
 pub async fn enter_transition(element: Element) {
     let transition = element.get_attribute("mixintransition").unwrap_or_default();
     let element_classes = element.class_list();
@@ -321,9 +323,11 @@ pub async fn enter_transition(element: Element) {
 }
 
 
-//transition when element is leaving
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+/// Transition function when element is leaving
+/// 
+/// For most case, you wont be needing this function as it is already implemented under the hood.
+#[cfg(feature = "transition")]
+#[cfg_attr(docsrs, doc(cfg(feature = "transition")))]
 pub async fn leave_transition(element: Element) {
     let transition = element.get_attribute("mixintransition").unwrap_or_default();
     let element_classes = element.class_list();
@@ -351,8 +355,8 @@ pub async fn leave_transition(element: Element) {
 }
 
 //wait for next frame, utils for mixin transition
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+#[cfg(feature = "transition")]
+#[cfg_attr(docsrs, doc(cfg(feature = "transition")))]
 fn next_frame() -> js_sys::Promise {
     js_sys::Promise::new(&mut |resolve, _| {
         let wrapper1 = wasm_bindgen::prelude::Closure::new(move || {
@@ -365,8 +369,8 @@ fn next_frame() -> js_sys::Promise {
 
 
 //wait for transition to be done
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+#[cfg(feature = "transition")]
+#[cfg_attr(docsrs, doc(cfg(feature = "transition")))]
 fn wait_for_transition(element: Element, transition: String, element_classes: web_sys::DomTokenList) -> js_sys::Promise {
     use std::{rc::Rc, cell::RefCell};
 

--- a/crates/hirola-core/src/mixins.rs
+++ b/crates/hirola-core/src/mixins.rs
@@ -291,8 +291,6 @@ pub async fn enter_transition(element: Element) {
     let element_classes = element.class_list();
 
     if !transition.is_empty() {
-        web_sys::console::log_1(&"enter transiotion2".into());
-
         //config
         if element_classes.contains(&format!("{}-leave-active", &transition)) {
             let _ = element_classes.remove_1(&format!("{}-leave-from", &transition));
@@ -330,7 +328,7 @@ pub async fn leave_transition(element: Element) {
     let transition = element.get_attribute("mixintransition").unwrap_or_default();
     let element_classes = element.class_list();
 
-    if !transition.is_empty() && !element_classes.contains(&format!("{}-leave-active", &transition)) {
+    if !transition.is_empty() {
         if element_classes.contains(&format!("{}-enter-active", &transition)) {
             let _ = element_classes.remove_1(&format!("{}-enter-from", &transition));
             let _ = element_classes.remove_1(&format!("{}-enter-active", &transition));

--- a/crates/hirola-core/src/mixins.rs
+++ b/crates/hirola-core/src/mixins.rs
@@ -262,10 +262,12 @@ pub fn transition<'a>(signal: &'a Signal<String>, onenter: bool) -> Box<dyn Fn(D
         let node = node.clone();
         let element = node.clone().dyn_into::<Element>().unwrap();
 
+        
         create_effect(move || {
             let signal = signal.get().to_string();
             element.set_attribute("mixintransition", &signal).unwrap();
         });
+
          
         if onenter {
             let node = node.clone();
@@ -281,42 +283,6 @@ pub fn transition<'a>(signal: &'a Signal<String>, onenter: bool) -> Box<dyn Fn(D
 }
 
 
-/*
-FIXME
-description: when using conditional rendering using `if` statement inside a block, programme cannot find transition property.
-
-recreating bug:
-step1: remove the `if !duration.is_empty()` statement below.
-
-step2: run the following
-let state = Signal::new(true);
-let state_copy = state.clone();
-html! {
-    <div>
-    <style>
-    //some styling
-    </style>
-    {
-        let res = *state.get();
-        match res {
-            true => html! {
-                <div mixin:transition=&transition(Signal::new("box".to_string()), true)>
-                    <h1>"first opt"</h1>
-                </div>
-            },
-            false => {
-                html! {
-                    <div mixin:transition=&transition(Signal::new("box".to_string()), true)>
-                        <h1>"second opt"</h1>
-                    </div>
-                }
-            }
-        }
-    }
-    <button on:click=move|_| state_copy.set(!*state_copy.get())>"toggle"</button>
-    </div>
-}
-*/
 //transition when element is entering
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
@@ -324,13 +290,20 @@ pub async fn enter_transition(element: Element) {
     let transition = element.get_attribute("mixintransition").unwrap_or_default();
     let element_classes = element.class_list();
 
-    if !transition.is_empty() && !element_classes.contains(&format!("{}-enter-active", &transition)) {
+    if !transition.is_empty() {
+        web_sys::console::log_1(&"enter transiotion2".into());
 
         //config
         if element_classes.contains(&format!("{}-leave-active", &transition)) {
             let _ = element_classes.remove_1(&format!("{}-leave-from", &transition));
             let _ = element_classes.remove_1(&format!("{}-leave-active", &transition));
             let _ = element_classes.remove_1(&format!("{}-leave-to", &transition));
+        }
+
+        if element_classes.contains(&format!("{}-enter-active", &transition)) {
+            let _ = element_classes.remove_1(&format!("{}-enter-from", &transition));
+            let _ = element_classes.remove_1(&format!("{}-enter-active", &transition));
+            let _ = element_classes.remove_1(&format!("{}-enter-to", &transition));
         }
 
         element_classes.add_1(&format!("{}-enter-from", &transition)).unwrap();
@@ -343,28 +316,8 @@ pub async fn enter_transition(element: Element) {
         let _ = element_classes.remove_1(&format!("{}-enter-from", transition)).unwrap();
         element_classes.add_1(&format!("{}-enter-to", transition)).unwrap();
 
-        //find transition duration
-        let transition_property = web_sys::window().unwrap()
-        .get_computed_style(&element).unwrap().unwrap()
-        .get_property_value("transition").unwrap();
-        let duration = transition_property.split_ascii_whitespace().collect::<Vec<&str>>();
-
-        //TODO: fix above bug
-        if !duration.is_empty() {
-            let mut duration = duration[1].to_string();
-            duration.pop();
-            let duration = (duration.parse::<f64>().unwrap() * 1000.).round() as i32;
-            
-            
-            let sleep = wasm_bindgen_futures::JsFuture::from(sleep(duration));
-            sleep.await.unwrap();
-        }
-
-        element_classes.remove_1(&format!("{}-enter-active", &transition)).unwrap();
-        element_classes.remove_1(&format!("{}-enter-to", &transition)).unwrap();
-        
-        
-        
+        let wait_for_transition_fut = wasm_bindgen_futures::JsFuture::from(wait_for_transition(element, transition, element_classes));
+        wait_for_transition_fut.await.unwrap();
     }
 
 }
@@ -385,7 +338,6 @@ pub async fn leave_transition(element: Element) {
         }
 
         element_classes.add_1(&format!("{}-leave-from", &transition)).unwrap();
-        
     
         let next_frame_fut = wasm_bindgen_futures::JsFuture::from(next_frame());
         next_frame_fut.await.unwrap();
@@ -394,36 +346,10 @@ pub async fn leave_transition(element: Element) {
         
         let _ = element_classes.remove_1(&format!("{}-leave-from", transition)).unwrap();
         element_classes.add_1(&format!("{}-leave-to", transition)).unwrap();
-
-        //find wait duration
-        let transiton_property = web_sys::window().unwrap()
-        .get_computed_style(&element).unwrap().unwrap()
-        .get_property_value("transition").unwrap();
-        let duration = transiton_property.split_ascii_whitespace().collect::<Vec<&str>>();
-        let mut duration = duration[1].to_string();
-        duration.pop();
-        let duration = (duration.parse::<f64>().unwrap() * 1000.).round() as i32;
         
-        
-        let sleep = wasm_bindgen_futures::JsFuture::from(sleep(duration));
-        sleep.await.unwrap();
-
-        element_classes.remove_1(&format!("{}-leave-active", &transition)).unwrap();
-        element_classes.remove_1(&format!("{}-leave-to", &transition)).unwrap();
+        let wait_for_transition_fut = wasm_bindgen_futures::JsFuture::from(wait_for_transition(element, transition, element_classes));
+        wait_for_transition_fut.await.unwrap();
     }
-}
-
-
-//sleep function utils for mixin transition
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-fn sleep(ms: i32) -> js_sys::Promise {
-    js_sys::Promise::new(&mut |resolve, _| {
-        web_sys::window()
-            .unwrap()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
-            .unwrap();
-    })
 }
 
 //wait for next frame, utils for mixin transition
@@ -438,3 +364,38 @@ fn next_frame() -> js_sys::Promise {
         wrapper1.forget();
     })
 }
+
+
+//wait for transition to be done
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+fn wait_for_transition(element: Element, transition: String, element_classes: web_sys::DomTokenList) -> js_sys::Promise {
+    use std::{rc::Rc, cell::RefCell};
+
+    js_sys::Promise::new(&mut |resolve, _| {
+        let element2 = element.clone();
+        let element_classes = element_classes.clone();
+        let transition = transition.clone();
+
+        let function: Rc<RefCell<Option<wasm_bindgen::prelude::Closure<dyn FnMut()>>>> = Rc::new(RefCell::new(None));
+        let function2 = function.clone();
+
+        let transition_function = wasm_bindgen::prelude::Closure::new(Box::new(move || {
+            let _ = element_classes.remove_1(&format!("{}-enter-active", &transition));
+            let _ = element_classes.remove_1(&format!("{}-enter-to", &transition));
+            let _ = element_classes.remove_1(&format!("{}-leave-active", &transition));
+            let _ = element_classes.remove_1(&format!("{}-leave-to", &transition));     
+
+            let a = function2.borrow();
+            let a = a.as_ref().unwrap();
+            element2.remove_event_listener_with_callback("transitionend", a.as_ref().unchecked_ref()).unwrap();
+
+            resolve.call0(&"".into()).unwrap();
+        }) as Box<dyn FnMut()>);    
+
+        
+        let _a = element.add_event_listener_with_callback("transitionend", transition_function.as_ref().unchecked_ref()).unwrap();
+        *function.borrow_mut() = Some(transition_function);
+    })
+}
+

--- a/crates/hirola-core/src/mixins.rs
+++ b/crates/hirola-core/src/mixins.rs
@@ -95,7 +95,45 @@ pub fn text<T: Display>(text: &Signal<T>) -> Box<dyn Fn(DomNode)> {
     Box::new(cb)
 }
 
+//show function for using mixin:transition feature
+#[cfg(feature = "async")]
+pub fn show(shown: &Signal<bool>) -> Box<dyn Fn(DomNode)> {
+    let signal = shown.clone();
+    let cb = move |node: DomNode| {
+        let element = node.unchecked_into::<HtmlElement>();
+        let signal = signal.clone();
+
+        create_effect(move || {
+            let res = *signal.get();
+            let signal = signal.clone();
+            let element = element.clone();
+            let task = async move {
+                let element = element.clone();
+                let style = element.style();
+                match res {
+                    true => {
+                        style.set_property("display", "block").unwrap();
+                        enter_transition(element.dyn_into::<Element>().unwrap()).await;
+                        
+                    },
+                    false => {
+                        leave_transition(element.dyn_into::<Element>().unwrap()).await;
+                        //if transition duration is very long, the `signal` might turned `true` in the transition period.
+                        //below is final check whether the `signal` is true of false
+                        if !*signal.get() {
+                            style.set_property("display", "none").unwrap();
+                        }
+                    },
+                }
+            };
+            let _fut = wasm_bindgen_futures::spawn_local(task);
+        });
+    };
+    Box::new(cb)
+}
+
 /// Mixin that adds text to a dom node
+#[cfg(not(feature = "async"))]
 pub fn show(shown: &Signal<bool>) -> Box<dyn Fn(DomNode)> {
     let signal = shown.clone();
     let cb = move |node: DomNode| {
@@ -162,4 +200,241 @@ pub mod model {
     pub fn input<T>(s: &Signal<T>) -> Model<HtmlInputElement, T> {
         Model(s.clone(), PhantomData)
     }
+}
+
+
+/// Mixin for playing with `transition`
+/// 
+/// _This mixin requires the following crate features to be activated: `async`_
+/// 
+/// The implementation is very similar to that in `VueJS` and `Alpine`. 
+/// 
+/// this mixin takes 2 arguments, a [`Signal`] of String and a boolean, 
+/// first argument will be the name of your transition. Reason for wrapping it in a `signal` is to make the 
+/// transition dynamic.
+/// Second argument is to call the transition when element first appear on the screen 
+/// 
+/// # Basic Example
+/// ```
+/// use hirola::prelude::{*, mixins::{show, transition}};
+/// 
+/// fn your_page(_app: HirolaApp) -> Dom {
+///     let state = Signal::new(true);
+///     let state_copy = state.clone();
+/// 
+///     html! {
+///         <div>
+///             <style>r##"
+///             .blue-box {
+///                 height: 100px;
+///                 width: 100px;
+///                 background-color: blue;
+///             }
+///             
+///            .box-enter-active,
+///            .box-leave-active {
+///                transition: all 0.3s ease;
+///            }
+///
+///            .box-enter-from,
+///            .box-leave-to {
+///                opacity: 0;
+///            }
+///
+///            .box-enter-to,
+///            .box-leave-from {
+///                opacity: 1;
+///             }
+///             "##</style>
+///             <div class="blue-box" mixin:show=&show(&state) mixin:transition=&transition(&Signal::new("box".to_string()), true) >
+///                 <h1>"Hello from blue box"</h1>
+///             </div>
+///             <button on:click=move |_| state_copy.set(!*state_copy.get())>"toggle blue box with transition"</button>
+///         </div>
+///     }
+/// } 
+/// ```
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+pub fn transition<'a>(signal: &'a Signal<String>, onenter: bool) -> Box<dyn Fn(DomNode) -> () + 'a> {
+    let cb = move |node: DomNode| {
+        let signal = signal.clone();
+        let node = node.clone();
+        let element = node.clone().dyn_into::<Element>().unwrap();
+
+        create_effect(move || {
+            let signal = signal.get().to_string();
+            element.set_attribute("mixintransition", &signal).unwrap();
+        });
+         
+        if onenter {
+            let node = node.clone();
+            let task = async move {
+                let element = node.dyn_ref::<Element>().unwrap();
+                enter_transition(element.clone()).await;
+            };
+            let _fut = wasm_bindgen_futures::spawn_local(task);
+        }
+        
+    };
+    Box::new(cb)
+}
+
+
+/*
+FIXME
+description: when using conditional rendering using `if` statement inside a block, programme cannot find transition property.
+
+recreating bug:
+step1: remove the `if !duration.is_empty()` statement below.
+
+step2: run the following
+let state = Signal::new(true);
+let state_copy = state.clone();
+html! {
+    <div>
+    <style>
+    //some styling
+    </style>
+    {
+        let res = *state.get();
+        match res {
+            true => html! {
+                <div mixin:transition=&transition(Signal::new("box".to_string()), true)>
+                    <h1>"first opt"</h1>
+                </div>
+            },
+            false => {
+                html! {
+                    <div mixin:transition=&transition(Signal::new("box".to_string()), true)>
+                        <h1>"second opt"</h1>
+                    </div>
+                }
+            }
+        }
+    }
+    <button on:click=move|_| state_copy.set(!*state_copy.get())>"toggle"</button>
+    </div>
+}
+*/
+//transition when element is entering
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+pub async fn enter_transition(element: Element) {
+    let transition = element.get_attribute("mixintransition").unwrap_or_default();
+    let element_classes = element.class_list();
+
+    if !transition.is_empty() && !element_classes.contains(&format!("{}-enter-active", &transition)) {
+
+        //config
+        if element_classes.contains(&format!("{}-leave-active", &transition)) {
+            let _ = element_classes.remove_1(&format!("{}-leave-from", &transition));
+            let _ = element_classes.remove_1(&format!("{}-leave-active", &transition));
+            let _ = element_classes.remove_1(&format!("{}-leave-to", &transition));
+        }
+
+        element_classes.add_1(&format!("{}-enter-from", &transition)).unwrap();
+        element_classes.add_1(&format!("{}-enter-active", &transition)).unwrap();
+    
+        let next_frame_fut = wasm_bindgen_futures::JsFuture::from(next_frame());
+        next_frame_fut.await.unwrap();
+
+        
+        let _ = element_classes.remove_1(&format!("{}-enter-from", transition)).unwrap();
+        element_classes.add_1(&format!("{}-enter-to", transition)).unwrap();
+
+        //find transition duration
+        let transition_property = web_sys::window().unwrap()
+        .get_computed_style(&element).unwrap().unwrap()
+        .get_property_value("transition").unwrap();
+        let duration = transition_property.split_ascii_whitespace().collect::<Vec<&str>>();
+
+        //TODO: fix above bug
+        if !duration.is_empty() {
+            let mut duration = duration[1].to_string();
+            duration.pop();
+            let duration = (duration.parse::<f64>().unwrap() * 1000.).round() as i32;
+            
+            
+            let sleep = wasm_bindgen_futures::JsFuture::from(sleep(duration));
+            sleep.await.unwrap();
+        }
+
+        element_classes.remove_1(&format!("{}-enter-active", &transition)).unwrap();
+        element_classes.remove_1(&format!("{}-enter-to", &transition)).unwrap();
+        
+        
+        
+    }
+
+}
+
+
+//transition when element is leaving
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+pub async fn leave_transition(element: Element) {
+    let transition = element.get_attribute("mixintransition").unwrap_or_default();
+    let element_classes = element.class_list();
+
+    if !transition.is_empty() && !element_classes.contains(&format!("{}-leave-active", &transition)) {
+        if element_classes.contains(&format!("{}-enter-active", &transition)) {
+            let _ = element_classes.remove_1(&format!("{}-enter-from", &transition));
+            let _ = element_classes.remove_1(&format!("{}-enter-active", &transition));
+            let _ = element_classes.remove_1(&format!("{}-enter-to", &transition));
+        }
+
+        element_classes.add_1(&format!("{}-leave-from", &transition)).unwrap();
+        
+    
+        let next_frame_fut = wasm_bindgen_futures::JsFuture::from(next_frame());
+        next_frame_fut.await.unwrap();
+
+        element_classes.add_1(&format!("{}-leave-active", &transition)).unwrap();
+        
+        let _ = element_classes.remove_1(&format!("{}-leave-from", transition)).unwrap();
+        element_classes.add_1(&format!("{}-leave-to", transition)).unwrap();
+
+        //find wait duration
+        let transiton_property = web_sys::window().unwrap()
+        .get_computed_style(&element).unwrap().unwrap()
+        .get_property_value("transition").unwrap();
+        let duration = transiton_property.split_ascii_whitespace().collect::<Vec<&str>>();
+        let mut duration = duration[1].to_string();
+        duration.pop();
+        let duration = (duration.parse::<f64>().unwrap() * 1000.).round() as i32;
+        
+        
+        let sleep = wasm_bindgen_futures::JsFuture::from(sleep(duration));
+        sleep.await.unwrap();
+
+        element_classes.remove_1(&format!("{}-leave-active", &transition)).unwrap();
+        element_classes.remove_1(&format!("{}-leave-to", &transition)).unwrap();
+    }
+}
+
+
+//sleep function utils for mixin transition
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+fn sleep(ms: i32) -> js_sys::Promise {
+    js_sys::Promise::new(&mut |resolve, _| {
+        web_sys::window()
+            .unwrap()
+            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
+            .unwrap();
+    })
+}
+
+//wait for next frame, utils for mixin transition
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+fn next_frame() -> js_sys::Promise {
+    js_sys::Promise::new(&mut |resolve, _| {
+        let wrapper1 = wasm_bindgen::prelude::Closure::new(move || {
+            web_sys::window().unwrap().request_animation_frame(&resolve).unwrap();
+        });
+        crate::utils::request_animation_frame(std::borrow::Borrow::borrow(&wrapper1));
+        wrapper1.forget();
+    })
 }

--- a/crates/hirola-core/src/utils.rs
+++ b/crates/hirola-core/src/utils.rs
@@ -95,3 +95,9 @@ pub fn loop_raf(task: Task) {
         tasks.borrow_mut().insert(task);
     });
 }
+
+pub fn request_animation_frame(f: &wasm_bindgen::prelude::Closure<dyn FnMut()>) {
+    web_sys::window().unwrap()
+        .request_animation_frame(wasm_bindgen::JsCast::unchecked_ref(f.as_ref()))
+        .unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@
 //! **Hirola** is an un-opinionated and extensible web framework for that is focused on simplicity and predictability.
 //!
 //! ## Example
-//! ```rust,no_run
+//! ```ignore
 //! use hirola::prelude::*;
 //!
-//! fn counter(_: &HirolaApp) -> Dom {
+//! pub fn counter(_: &HirolaApp) -> Dom {
 //!     let state = Signal::new(99);
 //!     let decerement = state.mut_callback(|count, _| *count - 1);
 //!     let incerement = state.mut_callback(|count, _| *count + 1);


### PR DESCRIPTION
`mixin:transition`

**process flow**
- `transition` function set a new `mixintransition` attribute for the `Element`.
- to activate the transition, `enter_transition` and `leave_transition` helper functions are called.

**current status**: _developing_

**current implementation**:
 - must have `transition` feature to use the mixin.
 - the implementation is very similar as in vuejs and alpine. reference: https://sebastiandedeyne.com/javascript-framework-diet/enter-leave-transitions/



Suggestions on how to make this mixin feature better would be really helpful